### PR TITLE
docs: claude-code-tips-findy-2026記事にWindowsのSnipping Toolの補足を追加

### DIFF
--- a/articles/claude-code-tips-findy-2026.md
+++ b/articles/claude-code-tips-findy-2026.md
@@ -72,7 +72,7 @@ $ claude "https://github.com/tonkotsuboy/fugafuga/pull/97 の
 
 ## Claude Codeに画像や画像内文字を伝えたい
 
-CleanShot Xを使う
+### macOSの場合はCleanShot Xを使う
 
 - スクショ
   - CleanShot X でスクリーン上の任意の領域をスクショしてClaude Codeに貼り付け
@@ -80,11 +80,18 @@ CleanShot Xを使う
   - OCR機能を使ってテキストをコピーできる
   - PDF、画像内文字、他アプリのUIなどの中にある文字を貼り付けたい
   - 画像を貼り付けて読み取らせるよりもトークン使用量が少ない
-- CleanShot XはmacOS専用。Windowsの情報求む
+- CleanShot XはmacOS専用
 
 https://cleanshot.com/
 
+### Windowsの場合はSnipping Toolを使う
 
+- Windowsの場合は、標準の「Snipping Tool」を使う
+  - `Windows + Shift + S` で起動し、任意領域のスクショも、スクショのOCRもできる
+  - 沖さん（[@448jp](https://x.com/448jp)）にコメントいただきました。ありがとうございます
+    - https://zenn.dev/ubie_dev/articles/claude-code-tips-findy-2026#comment-a403ac079daca7
+
+https://apps.microsoft.com/detail/9mz95kl8mr0l?hl=ja-JP&gl=JP
 
 ## GitHubのPRにスクショを貼り付けたい
 


### PR DESCRIPTION
## 概要

読者コメントを受けて、「Claude Codeに画像や画像内文字を伝えたい」セクションに、Windowsの標準ツール「Snipping Tool」についての補足を追加しました。

## 変更点

- `articles/claude-code-tips-findy-2026.md`
  - 「CleanShot XはmacOS専用。Windowsの情報求む」の行を、Windows向け代替ツールの案内に更新
  - `Windows + Shift + S` でSnipping Toolを起動することで、任意領域のスクショ・OCRが可能な旨を追記
  - 情報提供元の沖さん（[@448jp](https://x.com/448jp)）への謝辞とコメントへのリンクを追加

## 出典

- https://zenn.dev/ubie_dev/articles/claude-code-tips-findy-2026#comment-a403ac079daca7