### PR TITLE
chore(deps): zenn-cli ^0.4.7 → ^0.4.8 パッチ更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "prettier": "^3.8.3",
-    "zenn-cli": "^0.4.7"
+    "zenn-cli": "^0.4.8"
   },
   "devDependencies": {
     "lefthook": "^2.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.8.3
         version: 3.8.3
       zenn-cli:
-        specifier: ^0.4.7
-        version: 0.4.7
+        specifier: ^0.4.8
+        version: 0.4.8
     devDependencies:
       lefthook:
         specifier: ^2.1.6
@@ -1738,8 +1738,8 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  zenn-cli@0.4.7:
-    resolution: {integrity: sha512-PkCvxOmP5bvSRx+cGFaXBkOABUez0XVioq91X39oziUppwDPFiT47qlNPX3In8W0/ySASq0ur49TkOTtv5fiIw==}
+  zenn-cli@0.4.8:
+    resolution: {integrity: sha512-DIJv1udDCyHd6AqoBaQDjTMs/3fo1KUCpumgyy/X8Yt1SKB/egLmhhNmePGukkIhUZDld1+RLoMWOEBky6njwg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -4014,7 +4014,7 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  zenn-cli@0.4.7:
+  zenn-cli@0.4.8:
     dependencies:
       open: 10.2.0
       package-manager-detector: 1.6.0


### PR DESCRIPTION
## Summary

- zenn-cli を ^0.4.7 → ^0.4.8 にパッチ更新

既存の PR #105（dependabot: 0.4.6 → 0.4.7）は package.json が既に ^0.4.7 のため実質的に不要です。本 PR は最新の 0.4.8 まで更新します。

## Test plan

- [ ] `pnpm install` が正常に完了すること
- [ ] `npm run preview` でプレビューが正常に起動すること

https://claude.ai/code/session_01BcEWnQjeokpTdZqLb5kuhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcEWnQjeokpTdZqLb5kuhe)_