### PR TITLE
chore(deps): prettier・zenn-cli の更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prepare": "lefthook install || true"
   },
   "dependencies": {
-    "prettier": "^3.8.3",
-    "zenn-cli": "^0.4.8"
+    "prettier": "^3.9.1",
+    "zenn-cli": "^0.5.2"
   },
   "devDependencies": {
     "lefthook": "^2.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.9.1
+        version: 3.9.1
       zenn-cli:
-        specifier: ^0.4.8
-        version: 0.4.8
+        specifier: ^0.5.2
+        version: 0.5.2
     devDependencies:
       lefthook:
         specifier: ^2.1.9
@@ -1237,8 +1237,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.1:
+    resolution: {integrity: sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1727,8 +1727,8 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  zenn-cli@0.4.8:
-    resolution: {integrity: sha512-DIJv1udDCyHd6AqoBaQDjTMs/3fo1KUCpumgyy/X8Yt1SKB/egLmhhNmePGukkIhUZDld1+RLoMWOEBky6njwg==}
+  zenn-cli@0.5.2:
+    resolution: {integrity: sha512-HwZDjkZ8b2BExSwJKE4ERqm3e6+W9J8yNGHbOdKAmUWz4+Z9akGTijFFdK2QsPHp3E1acaGmKvE1jE5MZkLO0A==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -3189,7 +3189,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.3: {}
+  prettier@3.9.1: {}
 
   prh@5.4.4:
     dependencies:
@@ -3998,7 +3998,7 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  zenn-cli@0.4.8:
+  zenn-cli@0.5.2:
     dependencies:
       open: 10.2.0
       package-manager-detector: 1.6.0


### PR DESCRIPTION
## Summary\n\nsemver minor の範囲で依存関係を更新します。\n\n| パッケージ | 変更前 | 変更後 | 種類 |\n|---|---|---|---|\n| prettier | 3.8.3 | 3.9.1 | minor |\n| zenn-cli | 0.4.8 | 0.5.2 | minor |\n\n### prettier 3.9.1\n- Markdown リスト項目間の空行削除バグ修正 (3.8.4)\n- その他 minor 改善\n\n### zenn-cli 0.5.2\n- 脚注ツールチップ表示機能の追加 (0.5.0)\n- CodeSandbox / StackBlitz 埋め込みの改善 (0.5.1)\n- sanitize-html の更新 (0.5.1)\n\n## Test plan\n\n- [ ] `pnpm install` が正常に完了すること\n- [ ] `pnpm run preview` でプレビューが正常に起動すること\n\n> **Note**: Dependabot の #126 (prettier 3.8.4) と #127 (zenn-cli 0.5.1) より新しいバージョンに更新しています。マージ後はこれらの PR をクローズできます。

---
_Generated by [Claude Code](https://claude.ai/code/session_018ARQYrSHeYmf9M2xLEE2Hs)_