### PR TITLE
docs: TypeScript 7の正式リリースと書籍出版を2記事に追記

### DIFF
--- a/articles/typescript7-goodbye-legacy.md
+++ b/articles/typescript7-goodbye-legacy.md
@@ -146,11 +146,7 @@ After
 
 ## さいごに
 
-TypeScript 7は、ネイティブコンパイラーによるパフォーマンス向上だけでなく、長年の「今もう誰も使ってないだろう…」という設定とサヨナラするメジャーアップデートになります。
-
-2026年4月にはTypeScript 7.0のベータ版が公開されました。今後2か月以内（2026年6月〜7月）に正式リリースされる予定です。登場まであと少し。首を長くして待ちましょう。
-
-https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/
+TypeScript 7は、ネイティブコンパイラーによるパフォーマンス向上だけでなく、長年の「今もう誰も使ってないだろう…」という設定とサヨナラするメジャーアップデートです。
 
 参考記事
 
@@ -161,3 +157,17 @@ https://zenn.dev/ubie_dev/articles/typescript7-tsgo-whatsnew
 この記事は Ubie Tech Advent Calendar 2025 の 4日目の記事です。
 
 https://adventar.org/calendars/12070
+
+---
+
+（2026/07/09 追記）
+
+TypeScript 7が正式リリースされました。
+
+https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/
+
+TypeScript 7に対応した『TypeScriptコードレシピ集』を出版しました🌻
+
+https://www.amazon.co.jp/dp/4297156288
+
+https://kano.codes/entry/ts-code-recipe

--- a/articles/typescript7-tsgo-whatsnew.md
+++ b/articles/typescript7-tsgo-whatsnew.md
@@ -1032,10 +1032,6 @@ https://github.com/tonkotsuboy/tsgo-playground
 
 今回は、tsgoのインストール手順と、コンパイル速度の比較を行いました。小規模な例ではありましたが、「10倍高速化」という触れ込みは本当であることが確認できました。
 
-2026年4月にはTypeScript 7.0のベータ版が公開され、今後2か月以内（2026年6月〜7月）に正式リリースされる予定です。
-
-https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/
-
 余談ですが、本日は[TSKaigi 2025](https://2025.tskaigi.org/)が開催されており、会場では各所でtsgoの話題で盛り上がっていました。TypeScript好きの開発者が大注目のアップデートですね。
 
 ## 関連記事
@@ -1043,4 +1039,18 @@ https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/
 https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/
 
 https://devblogs.microsoft.com/typescript/typescript-native-port/
+
+---
+
+（2026/07/09 追記）
+
+TypeScript 7が正式リリースされました。
+
+https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/
+
+TypeScript 7に対応した『TypeScriptコードレシピ集』を出版しました🌻
+
+https://www.amazon.co.jp/dp/4297156288
+
+https://kano.codes/entry/ts-code-recipe
 


### PR DESCRIPTION
## 概要

TypeScript 7が正式リリースされたことを受けて、関連する既存記事2本を更新しました。

- `articles/typescript7-goodbye-legacy.md`
- `articles/typescript7-tsgo-whatsnew.md`

## 変更点

### 追記ブロックの追加（記事末尾）

両記事の末尾に「（2026/07/09 追記）」ブロックを追加しました。

- TypeScript 7 正式リリースのアナウンス記事へのリンク
- 『TypeScriptコードレシピ集』出版の告知（Amazon / kano.codes）

各URLはZennのリンクカードとして表示されるよう、単独行かつ前後に空行を入れています。

### リリース前提の記述を削除

正式リリース済みのため、本文に残っていた以下の記述を削除・修正しました。

- 「今後2か月以内（2026年6月〜7月）に正式リリースされる予定です」
- 「2026年4月にはTypeScript 7.0のベータ版が公開されました」とベータ版アナウンス記事へのリンク
- `typescript7-goodbye-legacy.md` の「メジャーアップデートになります」→「メジャーアップデートです」

## 確認方法

`npm run preview` でローカルプレビューを起動し、両記事の末尾でリンクカードが表示されることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015s4pqFAdHfq3Q7jDwjsnJ3